### PR TITLE
Улучшает резолвинг экстеншенов в import

### DIFF
--- a/src/path/get-extension-path.js
+++ b/src/path/get-extension-path.js
@@ -1,0 +1,66 @@
+// @flow
+import {existsSync} from 'fs';
+import {join} from 'path';
+
+/**
+ * Port of bitrix getLocalPath()
+ *
+ * @link https://bxapi.ru/src/?module_id=main&name=getLocalPath
+ * @param {string} projectRoot Absolute path to project root
+ * @param {string} relativePath Path relative to bitrix folder
+ * @returns {string|null}
+ */
+function getLocalPath(projectRoot: string, relativePath: string, baseFolder: string = 'bitrix') {
+	if (existsSync(join(projectRoot, 'local', relativePath))) {
+		return join(projectRoot, 'local', relativePath);
+	}
+	if (existsSync(join(projectRoot, baseFolder, relativePath))) {
+		return join(projectRoot, baseFolder, relativePath);
+	}
+	return null;
+}
+
+/**
+ * Guess absolute path to project root
+ *
+ * @param {string} context Project folder
+ * @returns {string}
+ */
+function guessProjectRoot(context: string) {
+	return context.split(/\/(bitrix|local)\//)[0];
+}
+
+
+/**
+ * Port of bitrix \Bitrix\Main\UI\Extension::getPath()
+ *
+ * @link https://bxapi.ru/src/?module_id=main&name=getPath
+ * @param {string} context Absolute path to built bundle
+ * @param {string} extensionName
+ * @returns {string|null}
+ */
+export function getExtensionPath(extensionName: string, context: string): ?string {
+	if (!(typeof extensionName === 'string')) {
+		return null;
+	}
+
+	const namespaces = extensionName.split('.');
+	if (namespaces.length < 2) {
+		return null;
+	}
+
+	const projectRoot = guessProjectRoot(context);
+	if (!projectRoot) {
+		return null;
+	}
+
+	const pathParts = ['js'];
+	for (let i = 0; i < namespaces.length; i++) {
+		if (!namespaces[i].match(/^[a-z0-9_\\.\-]+$/)) {
+			return null;
+		}
+		pathParts.push(namespaces[i]);
+	}
+
+	return getLocalPath(projectRoot, join(...pathParts));
+}

--- a/src/utils/get-globals.js
+++ b/src/utils/get-globals.js
@@ -1,7 +1,7 @@
 // @flow
-
 import {join} from 'path';
 import {existsSync} from 'fs';
+import {getExtensionPath} from '../path/get-extension-path';
 import type BundleConfig from '../@types/config';
 
 export default function getGlobals(imports: string[], {context}: BundleConfig): {[key: string]: string} {
@@ -19,6 +19,13 @@ export default function getGlobals(imports: string[], {context}: BundleConfig): 
 			const moduleJsRoot = join(moduleRoot, 'install', 'js', moduleName);
 			const extensionPath = join(moduleJsRoot, join(...parsedExtensionName));
 			configPath = join(extensionPath, 'bundle.config.js');
+		}
+
+		if (!existsSync(configPath)) {
+			const extensionPath = getExtensionPath(extensionName, context);
+			if (extensionPath) {
+				configPath = join(extensionPath, 'bundle.config.js');
+			}
 		}
 
 		let moduleAlias = 'BX';

--- a/test/utils/get-globals/data/bitrix/js/vendor/mymodule/myext-in-local/bundle.config.js
+++ b/test/utils/get-globals/data/bitrix/js/vendor/mymodule/myext-in-local/bundle.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	input: './src/app.js',
+	output: './dist/app.bundle.js',
+	namespace: 'BX.Vendor.MyModule.MyExtInBitrix'
+};

--- a/test/utils/get-globals/data/bitrix/js/vendor/mymodule/myext/bundle.config.js
+++ b/test/utils/get-globals/data/bitrix/js/vendor/mymodule/myext/bundle.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	input: './src/app.js',
+	output: './dist/app.bundle.js',
+	namespace: 'BX.Vendor.MyModule.MyExt'
+};

--- a/test/utils/get-globals/data/bitrix/modules/vendor.module/install/js/vendor/mymodule/myext-in-module-only/bundle.config.js
+++ b/test/utils/get-globals/data/bitrix/modules/vendor.module/install/js/vendor/mymodule/myext-in-module-only/bundle.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	input: './src/app.js',
+	output: './dist/app.bundle.js',
+	namespace: 'BX.Vendor.MyModule.MyExtInModuleOnly'
+};

--- a/test/utils/get-globals/data/bitrix/modules/vendor.module/install/js/vendor/mymodule/myext/bundle.config.js
+++ b/test/utils/get-globals/data/bitrix/modules/vendor.module/install/js/vendor/mymodule/myext/bundle.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	input: './src/app.js',
+	output: './dist/app.bundle.js',
+	namespace: 'BX.Vendor.MyModule.MyExt.WithWrongNamespace'
+};

--- a/test/utils/get-globals/data/local/js/vendor/mymodule/myext-in-local/bundle.config.js
+++ b/test/utils/get-globals/data/local/js/vendor/mymodule/myext-in-local/bundle.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	input: './src/app.js',
+	output: './dist/app.bundle.js',
+	namespace: 'BX.Vendor.MyModule.MyExtInLocal'
+};

--- a/test/utils/get-globals/get-globals.test.js
+++ b/test/utils/get-globals/get-globals.test.js
@@ -1,0 +1,73 @@
+import getGlobals from '../../../src/utils/get-globals';
+import assert from 'assert';
+import path from 'path';
+
+const projectRoot = path.resolve(__dirname, 'data');
+const vendorModuleDir = path.resolve(__dirname, 'data/bitrix/modules/vendor.mymodule');
+const vendorModuleJsDir = path.resolve(__dirname, 'data/bitrix/js/vendor/mymodule');
+
+const testInclusionFrom = (context) => {
+	it('Should resolve partner extension to path under bitrix/js', () => {
+		const expected = {
+			'vendor.mymodule.myext': 'BX.Vendor.MyModule.MyExt'
+		};
+		const actual = getGlobals(['vendor.mymodule.myext'], {context});
+
+		assert.deepEqual(actual, expected);
+	});
+	it('Should not resolve partner extension to bitrix/modules/<module>/install/js', () => {
+		const expected = {
+			'vendor.mymodule.myext-in-module-only': 'BX'
+		};
+		const actual = getGlobals(['vendor.mymodule.myext-in-module-only'], {context});
+
+		assert.deepEqual(actual, expected);
+	});
+
+	it('bitrix/js should have precedence over bitrix/modules/<module>/install/js', () => {
+		const expected = {
+			'vendor.mymodule.myext': 'BX.Vendor.MyModule.MyExt'
+		};
+		const notExpected = {
+			'vendor.mymodule.myext': 'BX.Vendor.MyModule.MyExtInModuleOnly'
+		};
+		const actual = getGlobals(['vendor.mymodule.myext'], {context});
+
+		assert.deepEqual(actual, expected);
+		assert.notDeepEqual(actual, notExpected);
+	});
+
+	it('local/ should have precedence over bitrix/ paths', () => {
+		const expected = {
+			'vendor.mymodule.myext-in-local': 'BX.Vendor.MyModule.MyExtInLocal'
+		};
+		const notExpected = {
+			'vendor.mymodule.myext-in-local': 'BX.Vendor.MyModule.MyExtInBitrix'
+		};
+		const actual = getGlobals(['vendor.mymodule.myext-in-local'], {context});
+
+		assert.deepEqual(actual, expected);
+		assert.notDeepEqual(actual, notExpected);
+	});
+}
+
+describe('utils/get-globals', () => {
+	it('Should be exported as function', () => {
+		assert(typeof getGlobals === 'function');
+	});
+
+	describe('With site templates context', () => {
+		const context = path.join(projectRoot, 'bitrix/templates/mytemplate/components/vendor.component/templates/.default');
+		testInclusionFrom(context);
+	});
+
+	describe('With component template context', () => {
+		const context = path.join(projectRoot, 'bitrix/components/vendor/component/templates/my-template');
+		testInclusionFrom(context);
+	});
+
+	describe('With third-party extension\'s context', () => {
+		const context = path.join(projectRoot, 'bitrix/js/vendor2/third-patry-extenion');
+		testInclusionFrom(context);
+	});
+});


### PR DESCRIPTION
- Добавляет поддержку партнерских модулей с точкой в названии
- Повторяет алгоритм поиска пути к расширению по php-версии: `\Bitrix\Main\UI\Extension::getPath()`

За корень проекта принимается первая папка, содержащая `bitrix` или `local`.